### PR TITLE
Fix missing dependency

### DIFF
--- a/diffusion_qa_agent/requirements.txt
+++ b/diffusion_qa_agent/requirements.txt
@@ -1,3 +1,4 @@
 langchain==0.3.23
 openai
 python-telegram-bot
+requests


### PR DESCRIPTION
## Summary
- add the missing `requests` dependency for the Telegram bot

## Testing
- `python3 -m py_compile diffusion_qa_agent/app.py`
